### PR TITLE
Add buttons to link to data in the publications list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "website",
       "version": "0.0.0",
       "dependencies": {
-        "@citation-js/core": "^0.5.4",
-        "@citation-js/plugin-bibtex": "^0.5.6",
+        "@citation-js/core": "0.6.1",
+        "@citation-js/plugin-bibtex": "^0.6.1",
         "@docusaurus/core": "^2.0.0-beta.14",
         "@docusaurus/preset-classic": "^2.0.0-beta.14",
         "@fortawesome/free-brands-svg-icons": "^6.0.0",
@@ -17,6 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "@fortawesome/react-fontawesome": "^0.1.17",
         "@mdx-js/react": "^1.6.21",
+        "@orcid/bibtex-parse-js": "^0.0.25",
         "@svgr/webpack": "^5.5.0",
         "bibtex": "^0.9.0",
         "clsx": "^1.1.1",
@@ -2025,17 +2026,17 @@
       }
     },
     "node_modules/@citation-js/core": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.4.tgz",
-      "integrity": "sha512-84as1w5v24DDTlzaRUtEBWIcj5wNw9A2ELqQs2ngrbFsc1psg1FbmwJplZQDSsiJHt+MfO23+DRmtOXyn7qXsg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-zvVxsAP4ciVHiZ60TmKTfjui4m6xeISSp/rtIhOcvZxZ70bBfkt83+kGnuI4xRlhB/oUrZN2fC9BSRKdivSobQ==",
       "dependencies": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
-        "isomorphic-fetch": "^3.0.0",
-        "sync-fetch": "^0.3.0"
+        "fetch-ponyfill": "^7.1.0",
+        "sync-fetch": "^0.4.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@citation-js/date": {
@@ -2055,19 +2056,19 @@
       }
     },
     "node_modules/@citation-js/plugin-bibtex": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.6.tgz",
-      "integrity": "sha512-VxKH1hgTwpiZ6A1NIq/wtovPqMspu1WQTt0x/09PulMM5qLecfv0tv/SIO1kd/azjmWVp2pOMoolKUMsRjEZSg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.6.1.tgz",
+      "integrity": "sha512-JMw9h9MUXH7YWvgN0j+A5xI4Fw3cHYcDMzpweeAcXBfjfnC6q30Dyvs2YxfUxNEKvWDgRQjAiNNIzgWXs9uK1Q==",
       "dependencies": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
         "moo": "^0.5.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@citation-js/core": "^0.5.0-alpha.0"
+        "@citation-js/core": "^0.6.0"
       }
     },
     "node_modules/@docsearch/css": {
@@ -3617,6 +3618,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@orcid/bibtex-parse-js": {
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+      "integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -7111,6 +7117,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/fetch-ponyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+      "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+      "dependencies": {
+        "node-fetch": "~2.6.1"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "license": "MIT",
@@ -8767,15 +8781,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
       }
     },
     "node_modules/jest-worker": {
@@ -12732,15 +12737,15 @@
       }
     },
     "node_modules/sync-fetch": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.1.tgz",
-      "integrity": "sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.4.1.tgz",
+      "integrity": "sha512-JDtyFEvnKUzt1CxRtzzsGgkBanEv8XRmLyJo0F0nGkpCR8EjYmpOJJXz8GA/SWtlPU0nAYh0+CNMNnFworGyOA==",
       "dependencies": {
-        "buffer": "^5.7.0",
+        "buffer": "^5.7.1",
         "node-fetch": "^2.6.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       }
     },
     "node_modules/tapable": {
@@ -13986,11 +13991,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -15550,14 +15550,14 @@
       }
     },
     "@citation-js/core": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.4.tgz",
-      "integrity": "sha512-84as1w5v24DDTlzaRUtEBWIcj5wNw9A2ELqQs2ngrbFsc1psg1FbmwJplZQDSsiJHt+MfO23+DRmtOXyn7qXsg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-zvVxsAP4ciVHiZ60TmKTfjui4m6xeISSp/rtIhOcvZxZ70bBfkt83+kGnuI4xRlhB/oUrZN2fC9BSRKdivSobQ==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
-        "isomorphic-fetch": "^3.0.0",
-        "sync-fetch": "^0.3.0"
+        "fetch-ponyfill": "^7.1.0",
+        "sync-fetch": "^0.4.1"
       }
     },
     "@citation-js/date": {
@@ -15571,9 +15571,9 @@
       "integrity": "sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ=="
     },
     "@citation-js/plugin-bibtex": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.6.tgz",
-      "integrity": "sha512-VxKH1hgTwpiZ6A1NIq/wtovPqMspu1WQTt0x/09PulMM5qLecfv0tv/SIO1kd/azjmWVp2pOMoolKUMsRjEZSg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.6.1.tgz",
+      "integrity": "sha512-JMw9h9MUXH7YWvgN0j+A5xI4Fw3cHYcDMzpweeAcXBfjfnC6q30Dyvs2YxfUxNEKvWDgRQjAiNNIzgWXs9uK1Q==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -16595,6 +16595,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@orcid/bibtex-parse-js": {
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+      "integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21"
@@ -19038,6 +19043,14 @@
         "xml-js": "^1.6.11"
       }
     },
+    "fetch-ponyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+      "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+      "requires": {
+        "node-fetch": "~2.6.1"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "requires": {
@@ -20067,15 +20080,6 @@
     },
     "isobject": {
       "version": "3.0.1"
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "jest-worker": {
       "version": "27.3.1",
@@ -22691,11 +22695,11 @@
       }
     },
     "sync-fetch": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.1.tgz",
-      "integrity": "sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.4.1.tgz",
+      "integrity": "sha512-JDtyFEvnKUzt1CxRtzzsGgkBanEv8XRmLyJo0F0nGkpCR8EjYmpOJJXz8GA/SWtlPU0nAYh0+CNMNnFworGyOA==",
       "requires": {
-        "buffer": "^5.7.0",
+        "buffer": "^5.7.1",
         "node-fetch": "^2.6.1"
       }
     },
@@ -23472,11 +23476,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@citation-js/core": "^0.5.4",
-    "@citation-js/plugin-bibtex": "^0.5.6",
+    "@citation-js/core": "0.6.1",
+    "@citation-js/plugin-bibtex": "^0.6.1",
     "@docusaurus/core": "^2.0.0-beta.14",
     "@docusaurus/preset-classic": "^2.0.0-beta.14",
     "@fortawesome/free-brands-svg-icons": "^6.0.0",
@@ -24,6 +24,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/react-fontawesome": "^0.1.17",
     "@mdx-js/react": "^1.6.21",
+    "@orcid/bibtex-parse-js": "^0.0.25",
     "@svgr/webpack": "^5.5.0",
     "bibtex": "^0.9.0",
     "clsx": "^1.1.1",

--- a/src/components/Publications.tsx
+++ b/src/components/Publications.tsx
@@ -5,7 +5,7 @@ import groupedPapers from "../data/publications-list.build";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFilePdf } from "@fortawesome/free-regular-svg-icons";
 import CodeBlock from "@theme/CodeBlock";
-import { faQuoteLeft } from "@fortawesome/free-solid-svg-icons";
+import { faDatabase, faQuoteLeft } from "@fortawesome/free-solid-svg-icons";
 import TOCInline from "@theme/TOCInline";
 
 export function shortName(firstName) {
@@ -51,6 +51,15 @@ function Paper(paper) {
           >
             <FontAwesomeIcon icon={faQuoteLeft} /> BibTeX
           </button>
+          {paper.data && (
+            <a
+              className="button button--outline button--sm button--secondary"
+              target="_blank"
+              href={paper.data}
+            >
+              <FontAwesomeIcon icon={faDatabase} /> Data
+            </a>
+          )}
           {paper.has_pdf && (
             <a
               className="button button--outline button--sm button--secondary"

--- a/src/pages/publications/journals.bib
+++ b/src/pages/publications/journals.bib
@@ -366,7 +366,7 @@
   doi     = {10.1109/TEM.2021.3122012},
   pages   = {16},
   year    = {2021},
-  month   = oct
+  month   = {oct}
 }
 
 @article{afzali2021human,


### PR DESCRIPTION
Many publications use the `data` field to link to data on the old website (which is not accessible anymore). For example:

https://github.com/DAS-Concordia/website/blob/8354c837432ebbf5f3d66f88dc8b7290b16e9c26/src/pages/publications/conferences.bib#L211-L218

We have two options to solve this issue:
1. Make the old URLs accessible again.
2. Upload the data on Zenodo.
