### PR TITLE
fix responsive issue

### DIFF
--- a/src/components/TeamMembers.module.css
+++ b/src/components/TeamMembers.module.css
@@ -19,3 +19,9 @@
 .memberButtons  a:hover {
   text-decoration: none;
 }
+
+@media (max-width: 550px) {
+  .memberName{
+    padding-top: 45px
+  }
+}

--- a/src/components/TeamMembers.tsx
+++ b/src/components/TeamMembers.tsx
@@ -98,7 +98,7 @@ const TeamMemberLarge = ({
         <div className="card__image">
           <img src={imgURL || importProfilePicture(id)} alt={name} />
         </div>
-        <div className="card__body">
+        <div className={clsx("card__body", styles.memberName)}>
           <h3 className="margin-bottom--none">{name}</h3>
           <span>{role}</span>
 


### PR DESCRIPTION
Fixed hidden member name on mobile screen. Screenshots attached:

Before:
<img width="332" alt="Screenshot 2025-05-12 at 4 36 21 PM" src="https://github.com/user-attachments/assets/e9647d90-dab9-4907-959a-3a94a80d360d" />

After:
<img width="291" alt="Screenshot 2025-05-12 at 4 32 30 PM" src="https://github.com/user-attachments/assets/e8e3c68b-0c00-4e7b-868b-f91754744db4" />
