### PR TITLE
include tab screen size in member page resonsiveness fix

### DIFF
--- a/src/components/TeamMembers.module.css
+++ b/src/components/TeamMembers.module.css
@@ -20,7 +20,7 @@
   text-decoration: none;
 }
 
-@media (max-width: 550px) {
+@media (max-width: 997px) {
   .memberName{
     padding-top: 45px
   }


### PR DESCRIPTION
Before:
<img width="980" alt="Screenshot 2025-05-13 at 12 33 34 PM" src="https://github.com/user-attachments/assets/7adfa70f-be86-4ef9-9269-e589d02f1f19" />

After:
<img width="921" alt="Screenshot 2025-05-13 at 12 33 39 PM" src="https://github.com/user-attachments/assets/d1776340-5d26-4163-9813-ac81c466fa62" />
